### PR TITLE
Add a mock server using the API specification

### DIFF
--- a/.github/workflows/publish-mockserver.yaml
+++ b/.github/workflows/publish-mockserver.yaml
@@ -1,0 +1,23 @@
+name: Publish mockserver
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+      - uses: azure/aks-set-context@v1
+        with:
+          creds: '${{ secrets.AZURE_CREDENTIALS }}'
+          cluster-name: vauhtijuoksu
+          resource-group: Vauhtijuoksu-Azure-Sponsorship
+      - uses: azure/setup-helm@v1
+        id: install
+      - name: Deploy mock server to AKS
+        run: |
+          helm upgrade --install mockserver deployment/mockserver

--- a/README.md
+++ b/README.md
@@ -8,3 +8,6 @@
 ```shell
 ./gradlew build
 ```
+
+## Testing the API
+A mock server using the API specification (from `main` branch) is served at 51.13.65.44.

--- a/api-doc/build.gradle.kts
+++ b/api-doc/build.gradle.kts
@@ -16,6 +16,7 @@ tasks {
             inputFile = file("$projectDir/openapi.yaml")
         }
     }
+
     generateSwaggerUI {
         swaggerSources {
             inputFile = file("$projectDir/openapi.yaml")

--- a/deployment/build.gradle.kts
+++ b/deployment/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    id("vauhtijuoksu-api.kotlin-common-conventions")
+}

--- a/deployment/mockserver/.helmignore
+++ b/deployment/mockserver/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deployment/mockserver/Chart.yaml
+++ b/deployment/mockserver/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: mockserver
+description: An examle mock server based on Vauhtijuoksu API specification
+type: application
+version: 0.1.0

--- a/deployment/mockserver/templates/_helpers.tpl
+++ b/deployment/mockserver/templates/_helpers.tpl
@@ -1,0 +1,44 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mockserver.name" -}}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "mockserver.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mockserver.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "mockserver.labels" -}}
+helm.sh/chart: {{ include "mockserver.chart" . }}
+{{ include "mockserver.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "mockserver.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mockserver.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/deployment/mockserver/templates/deployment.yaml
+++ b/deployment/mockserver/templates/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mockserver.fullname" . }}
+  labels:
+    {{- include "mockserver.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "mockserver.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "mockserver.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          resources:
+            limits:
+              cpu: 50m
+          env:
+            - name: OPENAPI_MOCK_SPECIFICATION_URL
+              value: {{ .Values.specification_url }}
+            - name: OPENAPI_MOCK_USE_EXAMPLES
+              value: {{ .Values.use_examples }}

--- a/deployment/mockserver/templates/service.yaml
+++ b/deployment/mockserver/templates/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mockserver.fullname" . }}
+  labels:
+    {{- include "mockserver.labels" . | nindent 4 }}
+  annotations:
+    service.beta.kubernetes.io/azure-load-balancer-resource-group: Vauhtijuoksu-Azure-Sponsorship
+spec:
+  type: LoadBalancer
+  loadBalancerIP: 51.13.65.44
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "mockserver.selectorLabels" . | nindent 4 }}

--- a/deployment/mockserver/values.yaml
+++ b/deployment/mockserver/values.yaml
@@ -1,0 +1,10 @@
+image:
+  repository: muonsoft/openapi-mock
+  tag: "v0.3.1"
+
+# Possible values:
+# no
+# if_present
+# exclusively
+use_examples: if_present
+specification_url: "https://raw.githubusercontent.com/Vauhtijuoksu/vauhtijuoksu-api/main/api-doc/openapi.yaml"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,3 +10,4 @@
 rootProject.name = "vauhtijuoksu-api"
 
 include("api-doc")
+include("deployment")


### PR DESCRIPTION
Added a mockserver (muonsoft/openapi-mock) that serves the current API
on Azure Kubernetes cluster, reachable by using the static IP given in
README.

The second commit just shows that the new CI works and will be removed before merging