### PR TITLE
Add Ingress with TLS for mockserver

### DIFF
--- a/deployment/infrastructure/README.md
+++ b/deployment/infrastructure/README.md
@@ -1,0 +1,30 @@
+# DNS + TLS
+NOTE: I didn't test these on fresh installation after a few try and errors. Versions aren't tagged so something might break in the future.
+
+Created by following and improvising, based on Microsoft tutorials here: https://docs.microsoft.com/en-us/azure/aks/ingress-tls
+
+```shell
+DNS_LABEL=dev.vauhtijuoksu.fi
+
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+helm install nginx-ingress ingress-nginx/ingress-nginx \
+    --set controller.replicaCount=1 \
+    --set controller.nodeSelector."kubernetes\.io/os"=linux \
+    --set controller.admissionWebhooks.patch.nodeSelector."kubernetes\.io/os"=linux \
+    --set defaultBackend.nodeSelector."kubernetes\.io/os"=linux \
+    --set controller.service.annotations."service\.beta\.kubernetes\.io/azure-dns-label-name"=$DNS_LABEL
+
+helm repo add jetstack https://charts.jetstack.io
+helm install cert-manager jetstack/cert-manager \
+--set installCRDs=true \
+--set nodeSelector."kubernetes\.io/os"=linux
+
+kubectl apply -f cert-issuer.yaml
+```
+Get newly created IP by running:
+```shell
+kubectl get service/nginx-ingress-ingress-nginx-controller
+```
+Configure DNS records to point at the IP
+
+Apply services with ingress. See mockserver for example.

--- a/deployment/infrastructure/cert-issuer.yaml
+++ b/deployment/infrastructure/cert-issuer.yaml
@@ -1,0 +1,18 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: internetjumala@vauhtijuoksu.fi
+    privateKeySecretRef:
+      name: letsencrypt-prod
+    solvers:
+      - http01:
+          ingress:
+            class: nginx
+            podTemplate:
+              spec:
+                nodeSelector:
+                  "kubernetes.io/os": linux

--- a/deployment/mockserver/templates/ingress.yaml
+++ b/deployment/mockserver/templates/ingress.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "mockserver.fullname" . }}
+  labels:
+    {{- include "mockserver.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/use-regex: "true"
+spec:
+  tls:
+    - hosts:
+        - dev.vauhtijuoksu.fi
+      secretName: tls-secret
+  rules:
+    - host: dev.vauhtijuoksu.fi
+      http:
+        paths:
+          - path: /(.*)
+            pathType: Prefix
+            backend:
+              service:
+                name: mockserver
+                port:
+                  number: 80

--- a/deployment/mockserver/templates/service.yaml
+++ b/deployment/mockserver/templates/service.yaml
@@ -7,8 +7,7 @@ metadata:
   annotations:
     service.beta.kubernetes.io/azure-load-balancer-resource-group: Vauhtijuoksu-Azure-Sponsorship
 spec:
-  type: LoadBalancer
-  loadBalancerIP: 51.13.65.44
+  type: ClusterIP
   ports:
     - port: 80
       targetPort: http


### PR DESCRIPTION
Created Ingress controller + cert-manager by following Microsoft
tutorial here
https://docs.microsoft.com/en-us/azure/aks/ingress-static-ip.