### PR TITLE
Add support for HTTP OPTIONS query

### DIFF
--- a/server/src/main/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/Server.kt
+++ b/server/src/main/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/Server.kt
@@ -4,6 +4,8 @@ import com.google.inject.Guice
 import fi.vauhtijuoksu.vauhtijuoksuapi.database.DatabaseModule
 import fi.vauhtijuoksu.vauhtijuoksuapi.server.impl.DonationsRouter
 import fi.vauhtijuoksu.vauhtijuoksuapi.server.impl.GameDataRouter
+import io.vertx.core.http.HttpHeaders
+import io.vertx.core.http.HttpMethod
 import io.vertx.core.http.HttpServer
 import io.vertx.ext.web.Router
 import io.vertx.ext.web.handler.SessionHandler
@@ -22,6 +24,13 @@ class Server @Inject constructor(
     private val logger = KotlinLogging.logger {}
 
     init {
+        router.options().handler { ctx ->
+            ctx.response().headers().add(
+                HttpHeaders.ALLOW,
+                "${HttpMethod.GET}, ${HttpMethod.POST}, ${HttpMethod.PATCH}, ${HttpMethod.OPTIONS}, ${HttpMethod.DELETE}"
+            )
+            ctx.response().end()
+        }
         gameDataRouter.configure(router)
         donationsRouter.configure(router)
         httpServer.requestHandler(router)

--- a/server/src/test/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/DonationApiTest.kt
+++ b/server/src/test/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/DonationApiTest.kt
@@ -5,6 +5,7 @@ import fi.vauhtijuoksu.vauhtijuoksuapi.models.Donation
 import fi.vauhtijuoksu.vauhtijuoksuapi.testdata.TestDonation.Companion.donation1
 import fi.vauhtijuoksu.vauhtijuoksuapi.testdata.TestDonation.Companion.donation2
 import io.vertx.core.Future
+import io.vertx.core.http.HttpMethod
 import io.vertx.core.json.JsonObject
 import io.vertx.ext.auth.authentication.UsernamePasswordCredentials
 import io.vertx.junit5.VertxTestContext
@@ -21,6 +22,32 @@ import org.mockito.Mockito.`when`
 import java.util.UUID
 
 class DonationApiTest : ServerTestBase() {
+    @Test
+    fun testDonationsOptions(testContext: VertxTestContext) {
+        client.request(HttpMethod.OPTIONS, "/donations").send()
+            .onFailure(testContext::failNow)
+            .onSuccess { res ->
+                testContext.verify {
+                    val allowedMethods = setOf("GET", "POST", "PATCH", "OPTIONS", "DELETE")
+                    assertEquals(allowedMethods, res.headers().get("Allow").split(", ").toSet())
+                }
+                testContext.completeNow()
+            }
+    }
+
+    @Test
+    fun testSingleDonationOptions(testContext: VertxTestContext) {
+        client.request(HttpMethod.OPTIONS, "/donations/${UUID.randomUUID()}").send()
+            .onFailure(testContext::failNow)
+            .onSuccess { res ->
+                testContext.verify {
+                    val allowedMethods = setOf("GET", "POST", "PATCH", "OPTIONS", "DELETE")
+                    assertEquals(allowedMethods, res.headers().get("Allow").split(", ").toSet())
+                }
+                testContext.completeNow()
+            }
+    }
+
     @Test
     fun testGetDonationNoData(testContext: VertxTestContext) {
         `when`(donationDb.getAll()).thenReturn(Future.succeededFuture(ArrayList()))

--- a/server/src/test/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/GameDataApiTest.kt
+++ b/server/src/test/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/GameDataApiTest.kt
@@ -5,6 +5,7 @@ import fi.vauhtijuoksu.vauhtijuoksuapi.models.GameData
 import fi.vauhtijuoksu.vauhtijuoksuapi.testdata.TestGameData.Companion.gameData1
 import fi.vauhtijuoksu.vauhtijuoksuapi.testdata.TestGameData.Companion.gameData2
 import io.vertx.core.Future
+import io.vertx.core.http.HttpMethod
 import io.vertx.core.json.JsonObject
 import io.vertx.ext.auth.authentication.UsernamePasswordCredentials
 import io.vertx.junit5.VertxTestContext
@@ -21,6 +22,33 @@ import org.mockito.Mockito.`when`
 import java.util.UUID
 
 class GameDataApiTest : ServerTestBase() {
+
+    @Test
+    fun testGamedataOptions(testContext: VertxTestContext) {
+        client.request(HttpMethod.OPTIONS, "/gamedata").send()
+            .onFailure(testContext::failNow)
+            .onSuccess { res ->
+                testContext.verify {
+                    val allowedMethods = setOf("GET", "POST", "PATCH", "OPTIONS", "DELETE")
+                    assertEquals(allowedMethods, res.headers().get("Allow").split(", ").toSet())
+                }
+                testContext.completeNow()
+            }
+    }
+
+    @Test
+    fun testSingleGamedataOptions(testContext: VertxTestContext) {
+        client.request(HttpMethod.OPTIONS, "/gamedata/${UUID.randomUUID()}").send()
+            .onFailure(testContext::failNow)
+            .onSuccess { res ->
+                testContext.verify {
+                    val allowedMethods = setOf("GET", "POST", "PATCH", "OPTIONS", "DELETE")
+                    assertEquals(allowedMethods, res.headers().get("Allow").split(", ").toSet())
+                }
+                testContext.completeNow()
+            }
+    }
+
     @Test
     fun testGetGameDataNoData(testContext: VertxTestContext) {
         `when`(gameDataDb.getAll()).thenReturn(Future.succeededFuture(ArrayList()))

--- a/server/src/test/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/ServerTest.kt
+++ b/server/src/test/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/ServerTest.kt
@@ -1,5 +1,6 @@
 package fi.vauhtijuoksu.vauhtijuoksuapi.server
 
+import io.vertx.core.http.HttpMethod
 import io.vertx.junit5.VertxTestContext
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -14,6 +15,19 @@ class ServerTest : ServerTestBase() {
                 testContext.verify {
                     assertEquals(404, res.statusCode())
                     verifyNoMoreInteractions(gameDataDb)
+                }
+                testContext.completeNow()
+            }
+    }
+
+    @Test
+    fun testServerRespondsWithOptions(testContext: VertxTestContext) {
+        client.request(HttpMethod.OPTIONS, "/").send()
+            .onFailure(testContext::failNow)
+            .onSuccess { res ->
+                testContext.verify {
+                    val allowedMethods = setOf("GET", "POST", "PATCH", "OPTIONS", "DELETE")
+                    assertEquals(allowedMethods, res.headers().get("Allow").split(", ").toSet())
                 }
                 testContext.completeNow()
             }


### PR DESCRIPTION
At the moment just generic response for all endpoint. Implementing per
endpoint might be nice.