### PR TITLE
Add cors handler for OPTIONS

### DIFF
--- a/server/src/main/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/ApiModule.kt
+++ b/server/src/main/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/ApiModule.kt
@@ -24,8 +24,6 @@ import io.vertx.ext.web.Router
 import io.vertx.ext.web.handler.AuthenticationHandler
 import io.vertx.ext.web.handler.BasicAuthHandler
 import io.vertx.ext.web.handler.CorsHandler
-import io.vertx.ext.web.handler.SessionHandler
-import io.vertx.ext.web.sstore.LocalSessionStore
 import javax.inject.Named
 
 class ApiModule : AbstractModule() {
@@ -52,12 +50,6 @@ class ApiModule : AbstractModule() {
     @Singleton
     fun getHttpServer(vertx: Vertx, conf: ServerConfiguration): HttpServer {
         return vertx.createHttpServer(HttpServerOptions().setPort(conf.port))
-    }
-
-    @Provides
-    @Singleton
-    fun getSessionHandler(vertx: Vertx): SessionHandler {
-        return SessionHandler.create(LocalSessionStore.create(vertx))
     }
 
     @Provides

--- a/server/src/main/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/ApiModule.kt
+++ b/server/src/main/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/ApiModule.kt
@@ -6,6 +6,8 @@ import com.google.inject.Singleton
 import com.google.inject.TypeLiteral
 import fi.vauhtijuoksu.vauhtijuoksuapi.models.Donation
 import fi.vauhtijuoksu.vauhtijuoksuapi.models.GameData
+import fi.vauhtijuoksu.vauhtijuoksuapi.server.DependencyInjectionConstants.Companion.AUTHENTICATED_CORS
+import fi.vauhtijuoksu.vauhtijuoksuapi.server.DependencyInjectionConstants.Companion.PUBLIC_CORS
 import fi.vauhtijuoksu.vauhtijuoksuapi.server.api.PatchInputValidator
 import fi.vauhtijuoksu.vauhtijuoksuapi.server.api.PostInputValidator
 import fi.vauhtijuoksu.vauhtijuoksuapi.server.configuration.ServerConfiguration
@@ -72,7 +74,7 @@ class ApiModule : AbstractModule() {
 
     @Provides
     @Singleton
-    @Named("authenticated")
+    @Named(AUTHENTICATED_CORS)
     fun getCorsHandlerAuth(conf: ServerConfiguration): CorsHandler {
         return CorsHandler.create(conf.corsHeader).allowCredentials(true)
             .allowedMethod(io.vertx.core.http.HttpMethod.GET)
@@ -83,7 +85,7 @@ class ApiModule : AbstractModule() {
 
     @Provides
     @Singleton
-    @Named("public")
+    @Named(PUBLIC_CORS)
     fun getCorsHandlerPublic(): CorsHandler {
         return CorsHandler.create()
     }

--- a/server/src/main/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/ApiModule.kt
+++ b/server/src/main/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/ApiModule.kt
@@ -15,6 +15,7 @@ import fi.vauhtijuoksu.vauhtijuoksuapi.server.impl.DonationPatchInputValidator
 import fi.vauhtijuoksu.vauhtijuoksuapi.server.impl.DonationPostInputValidator
 import fi.vauhtijuoksu.vauhtijuoksuapi.server.impl.GameDataPostInputValidator
 import io.vertx.core.Vertx
+import io.vertx.core.http.HttpMethod
 import io.vertx.core.http.HttpServer
 import io.vertx.core.http.HttpServerOptions
 import io.vertx.ext.auth.authentication.AuthenticationProvider
@@ -69,10 +70,11 @@ class ApiModule : AbstractModule() {
     @Named(AUTHENTICATED_CORS)
     fun getCorsHandlerAuth(conf: ServerConfiguration): CorsHandler {
         return CorsHandler.create(conf.corsHeader).allowCredentials(true)
-            .allowedMethod(io.vertx.core.http.HttpMethod.GET)
-            .allowedMethod(io.vertx.core.http.HttpMethod.POST)
-            .allowedMethod(io.vertx.core.http.HttpMethod.OPTIONS)
-            .allowedMethod(io.vertx.core.http.HttpMethod.PATCH)
+            .allowedMethod(HttpMethod.GET)
+            .allowedMethod(HttpMethod.POST)
+            .allowedMethod(HttpMethod.OPTIONS)
+            .allowedMethod(HttpMethod.PATCH)
+            .allowedMethod(HttpMethod.DELETE)
     }
 
     @Provides
@@ -80,5 +82,10 @@ class ApiModule : AbstractModule() {
     @Named(PUBLIC_CORS)
     fun getCorsHandlerPublic(): CorsHandler {
         return CorsHandler.create()
+            .allowedMethod(HttpMethod.GET)
+            .allowedMethod(HttpMethod.POST)
+            .allowedMethod(HttpMethod.OPTIONS)
+            .allowedMethod(HttpMethod.PATCH)
+            .allowedMethod(HttpMethod.DELETE)
     }
 }

--- a/server/src/main/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/DependencyInjectionConstants.kt
+++ b/server/src/main/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/DependencyInjectionConstants.kt
@@ -1,0 +1,8 @@
+package fi.vauhtijuoksu.vauhtijuoksuapi.server
+
+class DependencyInjectionConstants private constructor() {
+    companion object {
+        const val PUBLIC_CORS = "public_cors_handler"
+        const val AUTHENTICATED_CORS = "authenticated_cors_handler"
+    }
+}

--- a/server/src/main/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/Server.kt
+++ b/server/src/main/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/Server.kt
@@ -2,16 +2,19 @@ package fi.vauhtijuoksu.vauhtijuoksuapi.server
 
 import com.google.inject.Guice
 import fi.vauhtijuoksu.vauhtijuoksuapi.database.DatabaseModule
+import fi.vauhtijuoksu.vauhtijuoksuapi.server.DependencyInjectionConstants.Companion.PUBLIC_CORS
 import fi.vauhtijuoksu.vauhtijuoksuapi.server.impl.DonationsRouter
 import fi.vauhtijuoksu.vauhtijuoksuapi.server.impl.GameDataRouter
 import io.vertx.core.http.HttpHeaders
 import io.vertx.core.http.HttpMethod
 import io.vertx.core.http.HttpServer
 import io.vertx.ext.web.Router
+import io.vertx.ext.web.handler.CorsHandler
 import io.vertx.ext.web.handler.SessionHandler
 import mu.KotlinLogging
 import java.util.concurrent.CountDownLatch
 import javax.inject.Inject
+import javax.inject.Named
 import kotlin.system.exitProcess
 
 class Server @Inject constructor(
@@ -20,10 +23,12 @@ class Server @Inject constructor(
     gameDataRouter: GameDataRouter,
     donationsRouter: DonationsRouter,
     sessionHandler: SessionHandler,
+    @Named(PUBLIC_CORS) corsHandler: CorsHandler,
 ) {
     private val logger = KotlinLogging.logger {}
 
     init {
+        router.options().handler(corsHandler)
         router.options().handler { ctx ->
             ctx.response().headers().add(
                 HttpHeaders.ALLOW,

--- a/server/src/main/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/Server.kt
+++ b/server/src/main/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/Server.kt
@@ -10,7 +10,6 @@ import io.vertx.core.http.HttpMethod
 import io.vertx.core.http.HttpServer
 import io.vertx.ext.web.Router
 import io.vertx.ext.web.handler.CorsHandler
-import io.vertx.ext.web.handler.SessionHandler
 import mu.KotlinLogging
 import java.util.concurrent.CountDownLatch
 import javax.inject.Inject
@@ -22,7 +21,6 @@ class Server @Inject constructor(
     router: Router,
     gameDataRouter: GameDataRouter,
     donationsRouter: DonationsRouter,
-    sessionHandler: SessionHandler,
     @Named(PUBLIC_CORS) corsHandler: CorsHandler,
 ) {
     private val logger = KotlinLogging.logger {}
@@ -39,7 +37,6 @@ class Server @Inject constructor(
         gameDataRouter.configure(router)
         donationsRouter.configure(router)
         httpServer.requestHandler(router)
-        router.route().handler(sessionHandler)
     }
 
     fun start() {

--- a/server/src/main/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/impl/AbstractRouter.kt
+++ b/server/src/main/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/impl/AbstractRouter.kt
@@ -121,8 +121,8 @@ protected constructor(
 
     private fun post(router: Router) {
         router.post(endpoint)
-            .handler(authenticationHandler)
             .handler(authenticatedEndpointCorsHandler)
+            .handler(authenticationHandler)
             .handler(BodyHandler.create())
             .handler { ctx ->
                 val record: T
@@ -162,8 +162,8 @@ protected constructor(
 
     private fun delete(router: Router) {
         router.delete("$endpoint/:id")
-            .handler(authenticationHandler)
             .handler(authenticatedEndpointCorsHandler)
+            .handler(authenticationHandler)
             .handler { ctx ->
                 val id: UUID
                 try {
@@ -189,8 +189,8 @@ protected constructor(
     @Suppress("LongMethod") // This will probably shorten once there is centralized error handling
     private fun patch(router: Router) {
         router.patch("$endpoint/:id")
-            .handler(authenticationHandler)
             .handler(authenticatedEndpointCorsHandler)
+            .handler(authenticationHandler)
             .handler(BodyHandler.create())
             .handler { ctx ->
                 val id: UUID

--- a/server/src/main/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/impl/DonationsRouter.kt
+++ b/server/src/main/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/impl/DonationsRouter.kt
@@ -2,6 +2,8 @@ package fi.vauhtijuoksu.vauhtijuoksuapi.server.impl
 
 import fi.vauhtijuoksu.vauhtijuoksuapi.database.api.VauhtijuoksuDatabase
 import fi.vauhtijuoksu.vauhtijuoksuapi.models.Donation
+import fi.vauhtijuoksu.vauhtijuoksuapi.server.DependencyInjectionConstants.Companion.AUTHENTICATED_CORS
+import fi.vauhtijuoksu.vauhtijuoksuapi.server.DependencyInjectionConstants.Companion.PUBLIC_CORS
 import fi.vauhtijuoksu.vauhtijuoksuapi.server.api.Mapper
 import fi.vauhtijuoksu.vauhtijuoksuapi.server.api.PatchInputValidator
 import fi.vauhtijuoksu.vauhtijuoksuapi.server.api.PostInputValidator
@@ -15,9 +17,9 @@ class DonationsRouter
 constructor(
     db: VauhtijuoksuDatabase<Donation>,
     authenticationHandler: AuthenticationHandler,
-    @Named("authenticated")
+    @Named(AUTHENTICATED_CORS)
     authenticatedEndpointCorsHandler: CorsHandler,
-    @Named("public")
+    @Named(PUBLIC_CORS)
     publicEndpointCorsHandler: CorsHandler,
     postInputValidator: PostInputValidator<Donation>?,
     patchInputValidator: PatchInputValidator<Donation>?,

--- a/server/src/main/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/impl/GameDataRouter.kt
+++ b/server/src/main/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/impl/GameDataRouter.kt
@@ -2,6 +2,7 @@ package fi.vauhtijuoksu.vauhtijuoksuapi.server.impl
 
 import fi.vauhtijuoksu.vauhtijuoksuapi.database.api.VauhtijuoksuDatabase
 import fi.vauhtijuoksu.vauhtijuoksuapi.models.GameData
+import fi.vauhtijuoksu.vauhtijuoksuapi.server.DependencyInjectionConstants
 import fi.vauhtijuoksu.vauhtijuoksuapi.server.api.Mapper
 import fi.vauhtijuoksu.vauhtijuoksuapi.server.api.PostInputValidator
 import io.vertx.ext.web.handler.AuthenticationHandler
@@ -13,9 +14,9 @@ class GameDataRouter @Inject constructor(
     db: VauhtijuoksuDatabase<GameData>,
     postInputValidator: PostInputValidator<GameData>,
     authenticationHandler: AuthenticationHandler,
-    @Named("authenticated")
+    @Named(DependencyInjectionConstants.AUTHENTICATED_CORS)
     authenticatedEndpointCorsHandler: CorsHandler,
-    @Named("public")
+    @Named(DependencyInjectionConstants.PUBLIC_CORS)
     publicEndpointCorsHandler: CorsHandler,
 ) :
     AbstractRouter<GameData>(

--- a/server/src/test/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/ServerTest.kt
+++ b/server/src/test/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/ServerTest.kt
@@ -22,12 +22,15 @@ class ServerTest : ServerTestBase() {
 
     @Test
     fun testServerRespondsWithOptions(testContext: VertxTestContext) {
-        client.request(HttpMethod.OPTIONS, "/").send()
+        client.request(HttpMethod.OPTIONS, "/")
+            .putHeader("Origin", "http://example.com")
+            .send()
             .onFailure(testContext::failNow)
             .onSuccess { res ->
                 testContext.verify {
                     val allowedMethods = setOf("GET", "POST", "PATCH", "OPTIONS", "DELETE")
                     assertEquals(allowedMethods, res.headers().get("Allow").split(", ").toSet())
+                    assertEquals("*", res.getHeader("Access-Control-Allow-Origin"))
                 }
                 testContext.completeNow()
             }

--- a/server/src/test/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/ServerTest.kt
+++ b/server/src/test/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/ServerTest.kt
@@ -4,22 +4,8 @@ import io.vertx.core.http.HttpMethod
 import io.vertx.junit5.VertxTestContext
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.verifyNoMoreInteractions
 
 class ServerTest : ServerTestBase() {
-    @Test
-    fun testServerResponds(testContext: VertxTestContext) {
-        client.get("/").send()
-            .onFailure(testContext::failNow)
-            .onSuccess { res ->
-                testContext.verify {
-                    assertEquals(404, res.statusCode())
-                    verifyNoMoreInteractions(gameDataDb)
-                }
-                testContext.completeNow()
-            }
-    }
-
     @Test
     fun testServerRespondsWithOptions(testContext: VertxTestContext) {
         client.request(HttpMethod.OPTIONS, "/")


### PR DESCRIPTION
According to cors specifiation, non-simple requests, e.q.  PATCH, needs
to first check with OPTIONS whether a request is allowed. OPTIONS is
also subject to cors restrictions.

Implement cors for OPTIONS for all endpoints.