### PR TITLE
Implement readinessProbe

### DIFF
--- a/deployment/api-server/templates/deployment.yaml
+++ b/deployment/api-server/templates/deployment.yaml
@@ -22,6 +22,10 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /gamedata
+              port: http
           volumeMounts:
           - name: configuration
             mountPath: /configuration

--- a/deployment/build.gradle.kts
+++ b/deployment/build.gradle.kts
@@ -86,7 +86,7 @@ tasks {
                 }
                 exec {
                     workingDir = projectDir
-                    bashCommand("helm install postgres bitnami/postgresql -f kind-cluster/psql-values.yaml")
+                    bashCommand("helm install postgres bitnami/postgresql -f kind-cluster/psql-values.yaml --version ^10.15.1")
                 }
                 // Postgres secrets for vauhtijuoksu api. Created manually on production environment
                 exec {


### PR DESCRIPTION
Tests using cluster in CI sometimes fail because tests are executed,
before the service is actually ready.

Implement a readiness probe to make sure that at least Kubernetes waits
for the servers to start and connect to the database, befofe deeming the
deployment to be ready.

