### PR TITLE
Enable commenting from forks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,24 +36,11 @@ jobs:
           distributions-cache-enabled: true
           dependencies-cache-enabled: true
           configuration-cache-enabled: true
-      - name: Add coverage report to PR
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: madrapps/jacoco-report@v1.2
+      - name: Save coverage reports
+        uses: actions/upload-artifact@v2
         with:
-          title: Unit and integration test coverage
-          paths: ${{ github.workspace }}/build/reports/jacoco/jacocoRootReport/jacocoRootReport.xml
-          token: ${{ secrets.GITHUB_TOKEN }}
-          min-coverage-overall: 78 # Current coverage
-          min-coverage-changed-files: 80 # Okay target for now
-      - name: Add feature test coverage report to PR
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: madrapps/jacoco-report@v1.2
-        with:
-          title: Feature test coverage
-          paths: ${{ github.workspace }}/build/reports/jacoco/featureTestReport/featureTestReport.xml
-          token: ${{ secrets.GITHUB_TOKEN }}
-          min-coverage-overall: 0 # No tests yet
-          min-coverage-changed-files: 0
+          name: coverage results
+          path: "**/build/reports/jacoco/"
       - name: Save test results
         if: always()
         uses: actions/upload-artifact@v2

--- a/.github/workflows/comment.yaml
+++ b/.github/workflows/comment.yaml
@@ -1,0 +1,51 @@
+name: comment coverage on PR
+
+on:
+  workflow_run:
+    workflows: [ "build" ]
+    types:
+      - completed
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: >
+      ${{ github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Download artifacts
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{ github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "coverage results"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/coverage.zip', Buffer.from(download.data));
+      - run: unzip coverage.zip
+      - name: Add coverage report to PR
+        uses: madrapps/jacoco-report@v1.2
+        with:
+          title: Unit and integration test coverage
+          paths: ${{ github.workspace }}/build/reports/jacoco/jacocoRootReport/jacocoRootReport.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: 80
+          min-coverage-changed-files: 80
+      - name: Add feature test coverage report to PR
+        uses: madrapps/jacoco-report@v1.2
+        with:
+          title: Feature test coverage
+          paths: ${{ github.workspace }}/build/reports/jacoco/featureTestReport/featureTestReport.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: 0 # No tests yet
+          min-coverage-changed-files: 0


### PR DESCRIPTION
PRs from forks, such as those from Dependabot, are run as read-only,
and therefore cannot comment on PRs with coverage results.

Use instructions from
https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
to create a safe way to comment from forked PRs.

The workflow triggering doesn't work, unless the file is in main, so the maybe just try and merge this one, and see what happens. 