### PR TITLE
Switch to Temurin image

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/openjdk:17
+FROM eclipse-temurin:17-jre
 
 RUN mkdir /vauhtijuoksu-api
 


### PR DESCRIPTION
Jacoco did not for some reason work with a non-alpine OpenJdk image.

Switched to Temurin because that seems to work