### PR TITLE
Fix GET response format

### DIFF
--- a/server/src/main/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/impl/donation/DonationGetRouter.kt
+++ b/server/src/main/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/impl/donation/DonationGetRouter.kt
@@ -15,5 +15,6 @@ class DonationGetRouter
     db: VauhtijuoksuDatabase<Donation>
 ) : GetRouter<Donation>(
     publicEndpointCorsHandler,
-    db
+    db,
+    { donation: Donation -> DonationApiModel.fromDonation(donation).toJson() },
 )

--- a/server/src/main/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/impl/gamedata/GameDataGetRouter.kt
+++ b/server/src/main/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/impl/gamedata/GameDataGetRouter.kt
@@ -16,4 +16,5 @@ class GameDataGetRouter
 ) : GetRouter<GameData>(
     publicEndpointCorsHandler,
     db,
+    { gd: GameData -> GameDataApiModel.fromGameData(gd).toJson() },
 )

--- a/server/src/test/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/DonationApiTest.kt
+++ b/server/src/test/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/DonationApiTest.kt
@@ -72,7 +72,12 @@ class DonationApiTest : ServerTestBase() {
                 testContext.verify {
                     assertEquals(200, res.statusCode())
                     assertEquals("application/json", res.getHeader("content-type"))
-                    val expectedJson = jacksonObjectMapper().writeValueAsString(arrayListOf(donation1, donation2))
+                    val expectedJson = jacksonObjectMapper().writeValueAsString(
+                        arrayListOf(
+                            DonationApiModel.fromDonation(donation1),
+                            DonationApiModel.fromDonation(donation2)
+                        )
+                    )
                     assertEquals(expectedJson, res.bodyAsString())
                     verifyNoMoreInteractions(donationDb)
                 }
@@ -207,7 +212,7 @@ class DonationApiTest : ServerTestBase() {
                     assertEquals(200, res.statusCode())
                     assertEquals("application/json", res.getHeader("content-type"))
                     assertEquals(
-                        JsonObject(jacksonObjectMapper().writeValueAsString(donation1)),
+                        JsonObject(jacksonObjectMapper().writeValueAsString(DonationApiModel.fromDonation(donation1))),
                         JsonObject(res.bodyAsString())
                     )
                     verifyNoMoreInteractions(donationDb)

--- a/server/src/test/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/GameDataApiTest.kt
+++ b/server/src/test/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/GameDataApiTest.kt
@@ -74,7 +74,12 @@ class GameDataApiTest : ServerTestBase() {
                 testContext.verify {
                     assertEquals(200, res.statusCode())
                     assertEquals("application/json", res.getHeader("content-type"))
-                    val expectedJson = jacksonObjectMapper().writeValueAsString(arrayListOf(gameData1, gameData2))
+                    val expectedJson = jacksonObjectMapper().writeValueAsString(
+                        arrayListOf(
+                            GameDataApiModel.fromGameData(gameData1),
+                            GameDataApiModel.fromGameData(gameData2)
+                        )
+                    )
                     assertEquals(expectedJson, res.bodyAsString())
                     verifyNoMoreInteractions(gameDataDb)
                 }
@@ -242,7 +247,7 @@ class GameDataApiTest : ServerTestBase() {
                     assertEquals(200, res.statusCode())
                     assertEquals("application/json", res.getHeader("content-type"))
                     assertEquals(
-                        JsonObject(jacksonObjectMapper().writeValueAsString(gameData1)),
+                        JsonObject(jacksonObjectMapper().writeValueAsString(GameDataApiModel.fromGameData(gameData1))),
                         JsonObject(res.bodyAsString())
                     )
                     verifyNoMoreInteractions(gameDataDb)


### PR DESCRIPTION
Changing the architecture broke response objects. In the response,
Models were serialized, when ApiModels should've been used instead.

Fix GetRouter by adding toJson to serialize the respone data.