### PR TITLE
Fix logic when mixing incentives in code

### DIFF
--- a/server/src/main/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/impl/incentives/IncentiveService.kt
+++ b/server/src/main/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/impl/incentives/IncentiveService.kt
@@ -123,23 +123,24 @@ class IncentiveService
                     chosenIncentive.incentiveId == incentive.id
                 }
             }
-            val inc = IncentiveAndItsCodes(
+            return@map IncentiveAndItsCodes(
                 incentive,
                 incentiveCodes.flatMap { incentiveCode ->
                     val incentiveCodesWithShares = mutableListOf<IncentiveCodeAndShare>()
-                    for (chosenIncentive in incentiveCode.chosenIncentives) {
-                        incentiveCodesWithShares.add(
-                            IncentiveCodeAndShare(
-                                incentiveCode.generatedCode,
-                                1.0 / incentiveCode.chosenIncentives.size,
-                                chosenIncentive.parameter,
+                    incentiveCode.chosenIncentives
+                        .filter { chosenIncentive -> chosenIncentive.incentiveId == incentive.id }
+                        .forEach { chosenIncentive ->
+                            incentiveCodesWithShares.add(
+                                IncentiveCodeAndShare(
+                                    incentiveCode.generatedCode,
+                                    1.0 / incentiveCode.chosenIncentives.size,
+                                    chosenIncentive.parameter,
+                                )
                             )
-                        )
-                    }
+                        }
                     incentiveCodesWithShares
                 }.toSet(),
             )
-            return@map inc
         }
     }
 


### PR DESCRIPTION
Logic for calculating statuses mixed options from multiple
chosen incentives which caused incorrect sums and statuses.

Fixed by filtering chosen incentives by incentive id when
calculating statuses.