### PR TITLE
Use jacoco-report-aggregation -plugin

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
         with:
           title: Unit and integration test coverage
           update-comment: true
-          paths: ${{ github.workspace }}/build/reports/jacoco/jacocoRootReport/jacocoRootReport.xml
+          paths: ${{ github.workspace }}/server/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
           token: ${{ secrets.GITHUB_TOKEN }}
           min-coverage-overall: 78 # Current coverage
           min-coverage-changed-files: 80 # Okay target for now

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,32 +30,6 @@ tasks {
         }
     }
 
-    val jacocoRootReport by registering(JacocoReport::class) {
-        subprojects.filter {
-            // feature-tests have a separate report
-            it.name != "feature-tests"
-        }.forEach { subproject ->
-            // Depend on the subproject report so that those are generated those before the combined report
-            subproject.tasks.findByName("jacocoTestReport")?.let { task ->
-                dependsOn(task)
-            }
-            plugins.withType<JacocoPlugin>().configureEach {
-                subproject.tasks.matching {
-                    it.extensions.findByType<JacocoTaskExtension>() != null
-                }.configureEach {
-                    subproject.the<SourceSetContainer>().findByName("main")?.let {
-                        sourceSets(it)
-                    }
-                    executionData(this)
-                }
-            }
-        }
-        reports {
-            xml.required.set(true)
-            html.required.set(true)
-        }
-    }
-
     val featureTestReport by registering(JacocoReport::class) {
         subprojects.first { it.name == "feature-tests" }.let { featureTests ->
             featureTests.tasks.findByName("test")?.let {
@@ -83,6 +57,6 @@ tasks {
     }
 
     build {
-        finalizedBy(jacocoRootReport, featureTestReport)
+        finalizedBy(featureTestReport)
     }
 }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -6,6 +6,7 @@ import java.io.IOException
 plugins {
     id("vauhtijuoksu-api.implementation-conventions")
     id("application")
+    `jacoco-report-aggregation`
 }
 
 dependencies {
@@ -73,6 +74,10 @@ val dockerBuild by tasks.registering {
             bashCommand("docker image inspect $imageName:$imageTag | jq '.[0].Id' > build/image-hash")
         }
     }
+}
+
+tasks.check {
+    dependsOn(tasks.named<JacocoReport>("testCodeCoverageReport"))
 }
 
 val dockerImageConfiguration: Configuration by configurations.creating {


### PR DESCRIPTION
With gradle 7.4 there's an option to use built-in plugin for aggregating jacoco reports, instead of manually doing so.

Took the plugin into use as instructed here
https://docs.gradle.org/7.4/samples/sample_jvm_multi_project_with_code_coverage_distribution.html