### PR TITLE
Fix problems in featureTest deployments

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Build and test
         uses: eskatos/gradle-command-action@v2.3.3
         with:
-          arguments: build integrationTest --info
+          arguments: build --info
       - name: Add coverage report to PR
         if: ${{ github.event_name == 'pull_request' }}
         uses: madrapps/jacoco-report@v1.3
@@ -53,8 +53,8 @@ jobs:
           update-comment: true
           paths: ${{ github.workspace }}/build/reports/jacoco/featureTestReport/featureTestReport.xml
           token: ${{ secrets.GITHUB_TOKEN }}
-          min-coverage-overall: 0 # No tests yet
-          min-coverage-changed-files: 0
+          min-coverage-overall: 75
+          min-coverage-changed-files: 80
       - name: Save test results
         if: always()
         uses: actions/upload-artifact@v3

--- a/deployment/build.gradle.kts
+++ b/deployment/build.gradle.kts
@@ -120,7 +120,7 @@ tasks {
                     """
                 helm upgrade --install vauhtijuoksu-api api-server -f kind-cluster/vauhtijuoksu-api-values.yaml --set image.tag=${rootProject.version}
                 # Force restart, because in development pods might have a same dirty version if no commits were made
-                kubectl delete pod -l app=vauhtijuoksu-api
+                kubectl delete pod -l app.kubernetes.io/name=vauhtijuoksu-api
                 kubectl rollout status deployment vauhtijuoksu-api
                 """
                 )

--- a/feature-tests/build.gradle.kts
+++ b/feature-tests/build.gradle.kts
@@ -7,7 +7,6 @@ import org.jacoco.core.runtime.RemoteControlReader
 import org.jacoco.core.runtime.RemoteControlWriter
 import java.io.FileOutputStream
 import java.net.Socket
-import java.util.concurrent.TimeUnit
 import kotlin.random.Random
 
 plugins {
@@ -118,9 +117,12 @@ tasks {
                 logger.debug("Patching deployment")
                 val vauhtijuoksuApiDeployment = k8s.apps().deployments().inNamespace("default").withName("vauhtijuoksu-api")
                 vauhtijuoksuApiDeployment.patch(patch)
-                vauhtijuoksuApiDeployment.waitUntilReady(30, TimeUnit.SECONDS)
                 logger.debug("Deployment patched")
             }
+            exec {
+                bashCommand("kubectl rollout status deployment vauhtijuoksu-api")
+            }
+            logger.debug("Patched deployment rolled out")
         }
     }
 


### PR DESCRIPTION
Test deployment used wrong (probably old) label to delete pods, thus deleting nothing. Fixed by using correct label.

Kubernetes java client waitUntilReady apparently wasn't the same as kubernetes rollout status moniting, which caused tests to proceed before test pods were ready. This caused featureTest coverage numbers to wary between runs, as only some of the pods were used in tests and or coverage measurement. Fixed by using "kubectl rollout status" on the deployment.