### PR TITLE
Change CORS to allow credentials

### DIFF
--- a/server/src/main/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/ApiModule.kt
+++ b/server/src/main/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/ApiModule.kt
@@ -83,6 +83,7 @@ class ApiModule : AbstractModule() {
             .allowedMethod(HttpMethod.OPTIONS)
             .allowedMethod(HttpMethod.PATCH)
             .allowedMethod(HttpMethod.DELETE)
+            .allowCredentials(true)
 
     @Provides
     @Singleton


### PR DESCRIPTION
New OAuth uses cookies, which are not sent if CORS isn't set to allow credentials.