### PR TITLE
Update cors usage to allow OAuth with admin api

### DIFF
--- a/server/src/main/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/ApiModule.kt
+++ b/server/src/main/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/ApiModule.kt
@@ -17,6 +17,7 @@ import fi.vauhtijuoksu.vauhtijuoksuapi.server.impl.donation.DonationPostInputVal
 import fi.vauhtijuoksu.vauhtijuoksuapi.server.impl.gamedata.GameDataPatchInputValidator
 import fi.vauhtijuoksu.vauhtijuoksuapi.server.impl.gamedata.GameDataPostInputValidator
 import io.vertx.core.Vertx
+import io.vertx.core.http.CookieSameSite
 import io.vertx.core.http.HttpMethod
 import io.vertx.core.http.HttpServer
 import io.vertx.core.http.HttpServerOptions
@@ -71,13 +72,18 @@ class ApiModule : AbstractModule() {
 
     @Provides
     @Singleton
-    fun getSessionHandler(sessionStore: SessionStore): SessionHandler = SessionHandler.create(sessionStore)
+    fun getSessionHandler(conf: ServerConfiguration, sessionStore: SessionStore): SessionHandler =
+        SessionHandler.create(sessionStore)
+            .setCookieSameSite(CookieSameSite.NONE)
+            .setCookieSecureFlag(conf.sessionCookieSecure)
 
     @Provides
     @Singleton
     @Named(AUTHENTICATED_CORS)
     fun getCorsHandlerAuth(conf: ServerConfiguration): CorsHandler =
-        CorsHandler.create().addRelativeOrigin(conf.corsHeader).allowCredentials(true)
+        CorsHandler.create()
+            .addRelativeOrigin(conf.corsHeader)
+            .allowCredentials(true)
             .allowedMethod(HttpMethod.GET)
             .allowedMethod(HttpMethod.POST)
             .allowedMethod(HttpMethod.OPTIONS)

--- a/server/src/main/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/Server.kt
+++ b/server/src/main/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/Server.kt
@@ -10,7 +10,7 @@ import fi.vauhtijuoksu.vauhtijuoksuapi.server.ApiConstants.Companion.BAD_REQUEST
 import fi.vauhtijuoksu.vauhtijuoksuapi.server.ApiConstants.Companion.INTERNAL_SERVER_ERROR
 import fi.vauhtijuoksu.vauhtijuoksuapi.server.ApiConstants.Companion.NOT_FOUND
 import fi.vauhtijuoksu.vauhtijuoksuapi.server.ApiConstants.Companion.USER_ERROR_CODES
-import fi.vauhtijuoksu.vauhtijuoksuapi.server.DependencyInjectionConstants.Companion.PUBLIC_CORS
+import fi.vauhtijuoksu.vauhtijuoksuapi.server.DependencyInjectionConstants.Companion.AUTHENTICATED_CORS
 import fi.vauhtijuoksu.vauhtijuoksuapi.server.configuration.ConfigurationModule
 import fi.vauhtijuoksu.vauhtijuoksuapi.server.impl.PlayerInfoRouter
 import fi.vauhtijuoksu.vauhtijuoksuapi.server.impl.StreamMetadataRouter
@@ -57,7 +57,7 @@ class Server @Inject constructor(
     incentiveCodeRouter: IncentiveCodeRouter,
     playersRouter: PlayersRouter,
     timerRouter: TimerRouter,
-    @Named(PUBLIC_CORS) corsHandler: CorsHandler,
+    @Named(AUTHENTICATED_CORS) corsHandler: CorsHandler,
     sessionHandler: SessionHandler,
     oAuthProvider: OAuth2Auth,
     oauth2AuthHandler: OAuth2AuthHandler,

--- a/server/src/main/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/configuration/Config.kt
+++ b/server/src/main/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/configuration/Config.kt
@@ -37,4 +37,5 @@ data class ServerConfiguration(
     val port: Int,
     val htpasswdFileLocation: String,
     val corsHeader: String,
+    val sessionCookieSecure: Boolean = true, // Needs to be false for tests. Setting this to false in production will break login
 )

--- a/server/src/test/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/AuthTest.kt
+++ b/server/src/test/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/AuthTest.kt
@@ -14,7 +14,7 @@ import io.vertx.core.Future
 import io.vertx.core.json.JsonObject
 import io.vertx.ext.auth.authentication.UsernamePasswordCredentials
 import io.vertx.ext.web.client.WebClientSession
-import io.vertx.kotlin.coroutines.await
+import io.vertx.kotlin.coroutines.coAwait
 import kotlinx.coroutines.test.runTest
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import org.junit.jupiter.api.AfterAll
@@ -67,7 +67,7 @@ open class AuthTest : ServerTestBase() {
         val res = client.patch("/player-info")
             .authentication(UsernamePasswordCredentials(username, password))
             .sendJson(JsonObject().put("message", "ota tää"))
-            .await()
+            .coAwait()
         res.statusCode() shouldBe 200
         verify(playerInfoDb).save(any())
     }
@@ -85,14 +85,14 @@ open class AuthTest : ServerTestBase() {
         val login = sessionClient.get("/login")
             .followRedirects(true)
             .send()
-            .await()
+            .coAwait()
         login.statusCode() shouldBe 200
 
         `when`(discordClient.getUser(any())).thenReturn(DiscordUser("Nörtti", true).right())
 
         val patch = sessionClient.patch("/player-info")
             .sendJson(JsonObject().put("message", "ota tää"))
-            .await()
+            .coAwait()
         patch.statusCode() shouldBe 200
         verify(playerInfoDb).save(any())
     }
@@ -103,14 +103,14 @@ open class AuthTest : ServerTestBase() {
         val login = sessionClient.get("/login")
             .followRedirects(true)
             .send()
-            .await()
+            .coAwait()
         login.statusCode() shouldBe 200
 
         `when`(discordClient.getUser(any())).thenReturn(DiscordUser("Nörtti", false).right())
 
         val patch = sessionClient.patch("/player-info")
             .sendJson(JsonObject().put("message", "ota tää"))
-            .await()
+            .coAwait()
         patch.statusCode() shouldBe 403
     }
 
@@ -120,14 +120,14 @@ open class AuthTest : ServerTestBase() {
         val login = sessionClient.get("/login")
             .followRedirects(true)
             .send()
-            .await()
+            .coAwait()
         login.statusCode() shouldBe 200
 
         `when`(discordClient.getUser(any())).thenReturn(DiscordError.NOT_A_MEMBER.left())
 
         val patch = sessionClient.patch("/player-info")
             .sendJson(JsonObject().put("message", "ota tää"))
-            .await()
+            .coAwait()
         patch.statusCode() shouldBe 403
     }
 }

--- a/server/src/test/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/GameDataApiTest.kt
+++ b/server/src/test/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/GameDataApiTest.kt
@@ -147,14 +147,14 @@ class GameDataApiTest : ServerTestBase() {
         `when`(gameDataDb.add(any())).thenReturn(Future.succeededFuture())
         val body = JsonObject.mapFrom(GameDataApiModel.fromGameData(gameData1))
         body.remove("id")
-        client.post("/gamedata").putHeader("Origin", "https://vauhtijuoksu.fi")
+        client.post("/gamedata").putHeader("Origin", allowedOrigin)
             .authentication(UsernamePasswordCredentials(username, password))
             .sendJson(body)
             .onFailure(testContext::failNow)
             .onSuccess { res ->
                 testContext.verify {
                     assertEquals(201, res.statusCode())
-                    assertEquals(corsHeaderUrl, res.getHeader("Access-Control-Allow-Origin"))
+                    assertEquals(allowedOrigin, res.getHeader("Access-Control-Allow-Origin"))
                 }
                 testContext.completeNow()
             }

--- a/server/src/test/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/IncentivesTest.kt
+++ b/server/src/test/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/IncentivesTest.kt
@@ -155,14 +155,14 @@ class IncentivesTest : ServerTestBase() {
             ),
         )
         client.post(incentivesEndpoint)
-            .putHeader("Origin", "https://vauhtijuoksu.fi")
+            .putHeader("Origin", allowedOrigin)
             .authentication(UsernamePasswordCredentials(username, password))
             .sendJson(body)
             .onFailure(testContext::failNow)
             .onSuccess { res ->
                 testContext.verify {
                     assertEquals(201, res.statusCode())
-                    assertEquals(corsHeaderUrl, res.getHeader("Access-Control-Allow-Origin"))
+                    assertEquals(allowedOrigin, res.getHeader("Access-Control-Allow-Origin"))
                     val response = res.bodyAsJsonObject().mapTo(IncentiveApiModel::class.java)
                     assertEquals(IncentiveApiModel.fromIncentive(someIncentive).copy(id = response.id), response)
                     verify(incentiveDatabase).add(someIncentive.copy(id = response.id))
@@ -187,7 +187,7 @@ class IncentivesTest : ServerTestBase() {
         )
         body.remove("title")
         client.post(incentivesEndpoint)
-            .putHeader("Origin", "https://vauhtijuoksu.fi")
+            .putHeader("Origin", allowedOrigin)
             .authentication(UsernamePasswordCredentials(username, password))
             .sendJson(body)
             .onFailure(testContext::failNow)
@@ -223,13 +223,13 @@ class IncentivesTest : ServerTestBase() {
         `when`(donationDb.getAll()).thenReturn(Future.succeededFuture(listOf()))
         `when`(generatedIncentiveCodeDatabase.getAll()).thenReturn(Future.succeededFuture(listOf()))
         client.patch("$incentivesEndpoint/$id")
-            .putHeader("Origin", "https://vauhtijuoksu.fi")
+            .putHeader("Origin", allowedOrigin)
             .authentication(UsernamePasswordCredentials(username, password))
             .sendJson(JsonObject().put("end_time", null))
             .onSuccess { res ->
                 testContext.verify {
                     assertEquals(200, res.statusCode())
-                    assertEquals(corsHeaderUrl, res.getHeader("Access-Control-Allow-Origin"))
+                    assertEquals(allowedOrigin, res.getHeader("Access-Control-Allow-Origin"))
                     assertEquals(
                         IncentiveApiModel.fromIncentiveWithStatuses(
                             IncentiveWithStatuses(
@@ -264,7 +264,7 @@ class IncentivesTest : ServerTestBase() {
         `when`(donationDb.getAll()).thenReturn(Future.succeededFuture(listOf()))
         `when`(generatedIncentiveCodeDatabase.getAll()).thenReturn(Future.succeededFuture(listOf()))
         client.patch("$incentivesEndpoint/$id")
-            .putHeader("Origin", "https://vauhtijuoksu.fi")
+            .putHeader("Origin", allowedOrigin)
             .authentication(UsernamePasswordCredentials(username, password))
             .sendJson(JsonObject().put("end_time", newTime.toString()))
             .onSuccess { res ->
@@ -295,7 +295,7 @@ class IncentivesTest : ServerTestBase() {
     fun `patch returns 404 when the incentive does not exists`(testContext: VertxTestContext) {
         `when`(incentiveDatabase.getById(any())).thenReturn(Future.failedFuture(MissingEntityException("No such row")))
         client.patch("$incentivesEndpoint/${UUID.randomUUID()}")
-            .putHeader("Origin", "https://vauhtijuoksu.fi")
+            .putHeader("Origin", allowedOrigin)
             .authentication(UsernamePasswordCredentials(username, password))
             .sendJson(JsonObject().put("end_time", null))
             .onSuccess { res ->
@@ -311,7 +311,7 @@ class IncentivesTest : ServerTestBase() {
         val id = someIncentive.id
         `when`(incentiveDatabase.getById(id)).thenReturn(Future.succeededFuture(someIncentive))
         client.patch("$incentivesEndpoint/$id")
-            .putHeader("Origin", "https://vauhtijuoksu.fi")
+            .putHeader("Origin", allowedOrigin)
             .authentication(UsernamePasswordCredentials(username, password))
             .sendJson(JsonObject().put("title", null))
             .onSuccess { res ->

--- a/server/src/test/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/PlayerInfoApiTest.kt
+++ b/server/src/test/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/PlayerInfoApiTest.kt
@@ -79,13 +79,13 @@ class PlayerInfoApiTest : ServerTestBase() {
     @Test
     fun `patch accepts vauhtijuoksu origins`() = runTest {
         client.patch(playerInfoEndpoint)
-            .putHeader("Origin", "https://vauhtijuoksu.fi")
+            .putHeader("Origin", allowedOrigin)
             .authentication(UsernamePasswordCredentials(username, password))
             .sendJson(JsonObject())
             .coAwait()
             .let { res ->
                 assertEquals(200, res.statusCode())
-                assertEquals(corsHeaderUrl, res.getHeader("Access-Control-Allow-Origin"))
+                assertEquals(allowedOrigin, res.getHeader("Access-Control-Allow-Origin"))
                 verify(playerInfoDb).save(somePlayerInfo)
             }
     }

--- a/server/src/test/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/ServerTestBase.kt
+++ b/server/src/test/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/ServerTestBase.kt
@@ -79,7 +79,8 @@ open class ServerTestBase {
     protected val username = "vauhtijuoksu"
     protected val password = "vauhtijuoksu"
 
-    protected val corsHeaderUrl = "https://vauhtijuoksu.fi"
+    protected val corsHeaderUrl = "https://(\\w+[.])?vauhtijuoksu.fi"
+    protected val allowedOrigin = "https://newapi.vauhtijuoksu.fi"
 
     private fun getFreePort(): Int {
         val sock = ServerSocket(0)
@@ -121,6 +122,7 @@ open class ServerTestBase {
                         serverPort,
                         htpasswdFile,
                         corsHeaderUrl,
+                        false,
                     ),
                 )
                 bind(RedisConfiguration::class.java).toProvider(Providers.of(null))

--- a/server/src/test/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/StreamMetadataTest.kt
+++ b/server/src/test/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/StreamMetadataTest.kt
@@ -141,14 +141,14 @@ class StreamMetadataTest : ServerTestBase() {
     @Test
     fun `patch accepts vauhtijuoksu origins`(testContext: VertxTestContext) {
         client.patch(streamMetadataEndpoint)
-            .putHeader("Origin", "https://vauhtijuoksu.fi")
+            .putHeader("Origin", allowedOrigin)
             .authentication(UsernamePasswordCredentials(username, password))
             .sendJson(JsonObject())
             .onFailure(testContext::failNow)
             .onSuccess { res ->
                 testContext.verify {
                     assertEquals(200, res.statusCode())
-                    assertEquals(corsHeaderUrl, res.getHeader("Access-Control-Allow-Origin"))
+                    assertEquals(allowedOrigin, res.getHeader("Access-Control-Allow-Origin"))
                     verify(streamMetadataDatabase).save(someMetadataNoTimer)
                 }
                 testContext.completeNow()

--- a/server/src/test/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/TimersTest.kt
+++ b/server/src/test/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/TimersTest.kt
@@ -11,6 +11,7 @@ import io.vertx.core.json.JsonArray
 import io.vertx.core.json.JsonObject
 import io.vertx.ext.auth.authentication.UsernamePasswordCredentials
 import io.vertx.kotlin.coroutines.await
+import io.vertx.kotlin.coroutines.coAwait
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -88,11 +89,11 @@ class TimersTest : ServerTestBase() {
             ),
         )
         val res = client.post(timersEndpoint)
-            .putHeader("Origin", "https://vauhtijuoksu.fi")
+            .putHeader("Origin", allowedOrigin)
             .authentication(UsernamePasswordCredentials(username, password))
-            .sendJson(body).await()
+            .sendJson(body).coAwait()
         assertEquals(201, res.statusCode())
-        assertEquals(corsHeaderUrl, res.getHeader("Access-Control-Allow-Origin"))
+        assertEquals(allowedOrigin, res.getHeader("Access-Control-Allow-Origin"))
 
         val responseBody = res.bodyAsJsonObject().mapTo(TimerApiModel::class.java)
         assertEquals(TimerApiModel.from(timer1).copy(id = responseBody.id), responseBody)
@@ -111,7 +112,7 @@ class TimersTest : ServerTestBase() {
 
         body.remove("name")
         val res = client.post(timersEndpoint)
-            .putHeader("Origin", "https://vauhtijuoksu.fi")
+            .putHeader("Origin", allowedOrigin)
             .authentication(UsernamePasswordCredentials(username, password))
             .sendJson(body).await()
 
@@ -137,12 +138,12 @@ class TimersTest : ServerTestBase() {
         }
 
         val res = client.patch("$timersEndpoint/$id")
-            .putHeader("Origin", "https://vauhtijuoksu.fi")
+            .putHeader("Origin", allowedOrigin)
             .authentication(UsernamePasswordCredentials(username, password))
             .sendJson(JsonObject().put("end_time", null)).await()
 
         assertEquals(200, res.statusCode())
-        assertEquals(corsHeaderUrl, res.getHeader("Access-Control-Allow-Origin"))
+        assertEquals(allowedOrigin, res.getHeader("Access-Control-Allow-Origin"))
         assertEquals(
             JsonObject.mapFrom(TimerApiModel.from(expectedTimer)),
             res.bodyAsJsonObject(),
@@ -166,7 +167,7 @@ class TimersTest : ServerTestBase() {
         val id = timer1.id
         `when`(timerDb.getById(id)).thenReturn(Future.succeededFuture(timer1))
         val res = client.patch("$timersEndpoint/$id")
-            .putHeader("Origin", "https://vauhtijuoksu.fi")
+            .putHeader("Origin", allowedOrigin)
             .authentication(UsernamePasswordCredentials(username, password))
             .sendJson(JsonObject().put("name", null)).await()
         assertEquals(400, res.statusCode())


### PR DESCRIPTION
Non-simple requests, such as patch, send an options request before the actual request to check whether it's allowed. Change the options handler in server to allow authenticated requests.

OAuth login is checked from vertx-web.session cookie, set by api server after OAuth login flow.  To send the cookie with cors request, the cookie needs to have SameSite set to None and Secure set. Set the attributes in SessionHandler.