### PR TITLE
Gracefully handle Vertx errors in FailureHandler

### DIFF
--- a/server/src/main/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/ApiConstants.kt
+++ b/server/src/main/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/ApiConstants.kt
@@ -9,5 +9,6 @@ class ApiConstants private constructor() {
         const val NOT_FOUND = 404
         const val METHOD_NOT_ALLOWED = 405
         const val INTERNAL_SERVER_ERROR = 500
+        val USER_ERROR_CODES = 400..<500
     }
 }

--- a/server/src/main/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/Server.kt
+++ b/server/src/main/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/server/Server.kt
@@ -9,6 +9,7 @@ import fi.vauhtijuoksu.vauhtijuoksuapi.exceptions.VauhtijuoksuException
 import fi.vauhtijuoksu.vauhtijuoksuapi.server.ApiConstants.Companion.BAD_REQUEST
 import fi.vauhtijuoksu.vauhtijuoksuapi.server.ApiConstants.Companion.INTERNAL_SERVER_ERROR
 import fi.vauhtijuoksu.vauhtijuoksuapi.server.ApiConstants.Companion.NOT_FOUND
+import fi.vauhtijuoksu.vauhtijuoksuapi.server.ApiConstants.Companion.USER_ERROR_CODES
 import fi.vauhtijuoksu.vauhtijuoksuapi.server.DependencyInjectionConstants.Companion.PUBLIC_CORS
 import fi.vauhtijuoksu.vauhtijuoksuapi.server.configuration.ConfigurationModule
 import fi.vauhtijuoksu.vauhtijuoksuapi.server.impl.PlayerInfoRouter
@@ -131,12 +132,15 @@ class Server @Inject constructor(
                 }
 
                 else -> {
-                    logger.warn { "Uncaught error: ${cause.message}" }
-                    ctx.response().setStatusCode(INTERNAL_SERVER_ERROR).end()
+                    if (ctx.statusCode() in USER_ERROR_CODES) {
+                        ctx.response().setStatusCode(ctx.statusCode()).end()
+                    } else {
+                        logger.warn { "Unexpected status code ${ctx.statusCode()} in failure handler with error $cause" }
+                        ctx.response().setStatusCode(INTERNAL_SERVER_ERROR).end()
+                    }
                 }
             }
         }
-
         httpServer.requestHandler(router)
     }
 


### PR DESCRIPTION
Vertx internals, such as cors handler, fail requests by using ctx.fail(int). Such usage was not recognized by failure handler.

Improved the failure handler to recognzie 400-499 error codes, as they should be valid errors. Still log 500- codes.