### PR TITLE
Simplify database tests

### DIFF
--- a/database/src/test/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/database/impl/DonationDatabaseTest.kt
+++ b/database/src/test/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/database/impl/DonationDatabaseTest.kt
@@ -12,19 +12,6 @@ import org.junit.jupiter.api.Test
 import java.util.UUID
 
 class DonationDatabaseTest : VauhtijuoksuDatabaseTest<Donation>() {
-    override fun insertStatement(data: List<Donation>): String {
-        fun valuesStringForDonation(donation: Donation): String {
-            @Suppress("MaxLineLength")
-            return "('${donation.id}', '${donation.name}', '${donation.message}', '${df.format(donation.timestamp)}','${donation.amount}', '${donation.read}', ${donation.externalId?.run { "'${donation.externalId}'" } ?: "NULL"})"
-        }
-
-        var statement = "INSERT INTO donations VALUES "
-        for (donation in data) {
-            statement += "${valuesStringForDonation(donation)},"
-        }
-        return statement.trim(',')
-    }
-
     override fun existingRecord1(): Donation {
         return donation1
     }

--- a/database/src/test/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/database/impl/IncentiveDatabaseTest.kt
+++ b/database/src/test/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/database/impl/IncentiveDatabaseTest.kt
@@ -10,50 +10,6 @@ import org.junit.jupiter.api.Test
 import java.util.UUID
 
 class IncentiveDatabaseTest : VauhtijuoksuDatabaseTest<Incentive>() {
-    override fun insertStatement(data: List<Incentive>): String {
-        fun valuesStringForIncentive(incentive: Incentive): String {
-            fun intArrayOrNull(value: List<Int>?): String {
-                return value?.joinToString(",", "'{", "}'") ?: "NULL"
-            }
-
-            fun arrayOrNull(value: List<Any>?): String {
-                return value?.stream()?.map { "$it" }?.toList()?.joinToString(",", "'{", "}'") ?: "NULL"
-            }
-
-            fun valueOrNULL(value: Any?): String? {
-                return if (value != null) {
-                    "'$value'"
-                } else {
-                    null
-                }
-            }
-
-            return """(
-                '${incentive.id}',
-                ${valueOrNULL(incentive.gameId)},
-                '${incentive.title}',
-                '${incentive.endTime}',
-                '${incentive.type}',
-                '${incentive.info}',
-                ${intArrayOrNull(incentive.milestones)},
-                ${arrayOrNull(incentive.optionParameters)},
-                ${
-                if (incentive.openCharLimit == null) {
-                    "NULL"
-                } else {
-                    "${incentive.openCharLimit}"
-                }
-            }
-                )"""
-        }
-
-        var statement = "INSERT INTO incentives VALUES "
-        for (incentive in data) {
-            statement += "${valuesStringForIncentive(incentive)},"
-        }
-        return statement.trim(',')
-    }
-
     override fun existingRecord1(): Incentive {
         return TestIncentive.incentive1
     }

--- a/database/src/test/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/database/impl/PlayerDatabaseTest.kt
+++ b/database/src/test/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/database/impl/PlayerDatabaseTest.kt
@@ -10,18 +10,6 @@ import org.junit.jupiter.api.Test
 import java.util.*
 
 class PlayerDatabaseTest : VauhtijuoksuDatabaseTest<Player>() {
-    override fun insertStatement(data: List<Player>): String {
-        fun valuesStringForPlayer(player: Player): String {
-            return "('${player.id}', '${player.displayName}', '${player.twitchChannel}', '${player.discordNick}')"
-        }
-
-        var statement = "INSERT INTO players VALUES "
-        for (player in data) {
-            statement += "${valuesStringForPlayer(player)},"
-        }
-        return statement.trim(',')
-    }
-
     override fun existingRecord1(): Player {
         return TestPlayer.player1
     }

--- a/database/src/test/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/database/impl/TimerDatabaseTest.kt
+++ b/database/src/test/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/database/impl/TimerDatabaseTest.kt
@@ -52,18 +52,6 @@ class TimerDatabaseTest : VauhtijuoksuDatabaseTest<Timer>() {
         "timer 3",
     )
 
-    override fun insertStatement(data: List<Timer>): String {
-        fun valuesStringForTimer(timer: Timer): String {
-            return "('${timer.id}', '${timer.startTime}', '${timer.endTime}', '${timer.name}')"
-        }
-
-        var statement = "INSERT INTO timers VALUES "
-        for (timer in data) {
-            statement += "${valuesStringForTimer(timer)},"
-        }
-        return statement.trim(',')
-    }
-
     override fun existingRecord1(): Timer {
         return timer1
     }

--- a/database/src/test/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/database/impl/VauhtijuoksuDatabaseTest.kt
+++ b/database/src/test/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/database/impl/VauhtijuoksuDatabaseTest.kt
@@ -35,8 +35,6 @@ abstract class VauhtijuoksuDatabaseTest<T : Model> {
     var pg: PostgreSQLContainer<Nothing> =
         PostgreSQLContainer<Nothing>("postgres:10").withDatabaseName("vauhtijuoksu-api")
 
-    abstract fun insertStatement(data: List<T>): String
-
     abstract fun existingRecord1(): T
     abstract fun existingRecord2(): T
     abstract fun newRecord(): T
@@ -75,9 +73,10 @@ abstract class VauhtijuoksuDatabaseTest<T : Model> {
     }
 
     protected open fun insertExistingRecords(): Future<Unit> {
-        return sqlClient.query(insertStatement(listOf(existingRecord1(), existingRecord2())))
-            .execute()
-            .mapEmpty()
+        return db.add(existingRecord1())
+            .flatMap {
+                db.add(existingRecord2())
+            }.mapEmpty()
     }
 
     @Test


### PR DESCRIPTION
Using insertStatement instead of using the add method in class under test created a lot of complexity and questionable value. Removed it in favor of simpler tests.