### PR TITLE
Remove Vertx test context from database tests

### DIFF
--- a/database/src/test/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/database/impl/DonationDatabaseTest.kt
+++ b/database/src/test/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/database/impl/DonationDatabaseTest.kt
@@ -6,7 +6,8 @@ import fi.vauhtijuoksu.vauhtijuoksuapi.models.Donation
 import fi.vauhtijuoksu.vauhtijuoksuapi.testdata.TestDonation.Companion.donation1
 import fi.vauhtijuoksu.vauhtijuoksuapi.testdata.TestDonation.Companion.donation2
 import fi.vauhtijuoksu.vauhtijuoksuapi.testdata.TestDonation.Companion.donation3
-import io.vertx.junit5.VertxTestContext
+import io.vertx.kotlin.coroutines.coAwait
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import java.util.UUID
@@ -37,31 +38,29 @@ class DonationDatabaseTest : VauhtijuoksuDatabaseTest<Donation>() {
     }
 
     @Test
-    fun testUpdate(testContext: VertxTestContext) {
+    fun testUpdate() = runTest {
         val newDonation = donation1.copy(read = true, message = null)
         db.update(donation1.copy(read = true, message = null))
-            .compose { db.getAll() }
-            .onFailure(testContext::failNow)
-            .onSuccess { res ->
-                testContext.verify {
-                    assertEquals(listOf(newDonation, donation2), res)
-                }
-                testContext.completeNow()
+            .coAwait()
+
+        db.getAll()
+            .coAwait()
+            .let { res ->
+                assertEquals(listOf(newDonation, donation2), res)
             }
     }
 
     @Test
-    fun testUpdatingNonExistingRecord(testContext: VertxTestContext) {
+    fun testUpdatingNonExistingRecord() = runTest {
         db.update(donation3)
-            .failOnSuccess(testContext)
-            .recoverIfMissingEntity(testContext)
-            .compose { db.getAll() }
-            .onSuccess { res ->
-                testContext.verify {
-                    assertEquals(listOf(donation1, donation2), res)
-                }
-                testContext.completeNow()
+            .failOnSuccess()
+            .recoverIfMissingEntity()
+            .coAwait()
+
+        db.getAll()
+            .coAwait()
+            .let { res ->
+                assertEquals(listOf(donation1, donation2), res)
             }
-            .onFailure(testContext::failNow)
     }
 }

--- a/database/src/test/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/database/impl/TestUtils.kt
+++ b/database/src/test/kotlin/fi/vauhtijuoksu/vauhtijuoksuapi/database/impl/TestUtils.kt
@@ -2,24 +2,18 @@ package fi.vauhtijuoksu.vauhtijuoksuapi.database.impl
 
 import fi.vauhtijuoksu.vauhtijuoksuapi.exceptions.MissingEntityException
 import io.vertx.core.Future
-import io.vertx.junit5.VertxTestContext
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.fail
 
-internal fun <V> Future<V>.failOnSuccess(testContext: VertxTestContext): Future<V> {
-    return this.onSuccess { testContext.failNow("Expected to fail") }
-}
-
-internal fun <V> Future<V>.recoverIfMissingEntity(testContext: VertxTestContext): Future<V> {
-    return this.recover {
-        testContext.verify {
-            assertTrue(it is MissingEntityException)
-        }
-        return@recover Future.succeededFuture()
+internal fun <V> Future<V>.failOnSuccess(): Future<V> {
+    return this.onSuccess {
+        fail("Expected to fail")
     }
 }
 
-internal fun <V> Future<V>.completeOnSuccessOrFail(testContext: VertxTestContext): Future<V> {
-    return this.onSuccess {
-        testContext.completeNow()
-    }.onFailure(testContext::failNow)
+internal fun <V> Future<V>.recoverIfMissingEntity(): Future<V> {
+    return this.recover {
+        assertTrue(it is MissingEntityException)
+        return@recover Future.succeededFuture()
+    }
 }


### PR DESCRIPTION
It's easy to make mistakes with test context where tests pass where they shouldn't. Switch to more ergonomic runTest and coAwait so that errors pop up and stack traces are better.