### PR TITLE
Use GH runner curl

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,10 +29,13 @@ jobs:
       - name: Set version
         run: |
           echo "VERSION=$(./scripts/version.sh)" >> $GITHUB_ENV
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4.3.1
       - name: Build and test
-        run: ./gradlew build --info
+        uses: burrunan/gradle-cache-action@v3
+        with:
+          concurrent: true
+          arguments: |
+            build
+            --info
       - name: Add coverage report to PR
         if: ${{ github.event_name == 'pull_request' }}
         uses: madrapps/jacoco-report@v1.6

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,12 +20,6 @@ jobs:
         with:
           distribution: adopt
           java-version: 21
-      - name: Install a newer curl
-        # Integration tests utilize --retry-all-errors, which is added in curl 7.71.0
-        run: |
-          curl -vL https://github.com/moparisthebest/static-curl/releases/download/v7.78.0/curl-amd64 -o /tmp/curl
-          sudo install /tmp/curl /usr/local/bin/curl
-          echo "/usr/local/bin" >> $GITHUB_PATH
       - name: Set version
         run: |
           echo "VERSION=$(./scripts/version.sh)" >> $GITHUB_ENV


### PR DESCRIPTION
GH runners nowadays have a new enough curl version so we no longer need to install one manually.